### PR TITLE
Convert sustineo/spotify-utils to GitHub Actions

### DIFF
--- a/.github/workflows/spotify-utils.yml
+++ b/.github/workflows/spotify-utils.yml
@@ -1,0 +1,97 @@
+name: sustineo/spotify-utils
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  PYPI_TOKEN: "${{ secrets.PYPI_TOKEN }}"
+  SPOTIFY_UTILS_CLIENT_ID: "${{ secrets.SPOTIFY_UTILS_CLIENT_ID }}"
+  SPOTIFY_UTILS_CLIENT_SECRET: "${{ secrets.SPOTIFY_UTILS_CLIENT_SECRET }}"
+  SPOTIFY_UTILS_REDIRECT_URI: "${{ secrets.SPOTIFY_UTILS_REDIRECT_URI }}"
+  DOCKERHUB_USER: fabieu
+  DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"
+  CONTAINER_REGISTRY_USER: "${{ secrets.CONTAINER_REGISTRY_USER }}"
+  CONTAINER_REGISTRY_PASSWORD: "${{ secrets.CONTAINER_REGISTRY_PASSWORD }}"
+jobs:
+  prepare-environment:
+    runs-on:
+      - self-hosted
+      - gitlab-org-docker
+    container:
+      image: python:3.12.0-slim
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "web" || ${{ github.event_name }} == "api" || ${{ github.event_name }} == "push" && ${{ github.ref }} == $CI_DEFAULT_BRANCH
+    timeout-minutes: 60
+    env:
+      PIP_CACHE_DIR: "${{ github.workspace }}/.cache/pip"
+      POETRY_VERSION: 1.6.1
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+    - uses: actions/cache@v3.3.2
+      with:
+        path: ".cache/pip"
+        key: default
+    - run: pip install poetry==$POETRY_VERSION
+    - run: echo "Expanding version as environment variable"
+    - run: echo "VERSION=$(poetry version -s)" > .env
+    - run: cat .env
+#     # 'artifacts.dotenv' was not transformed because there is no suitable equivalent in GitHub Actions
+  publish-job:
+    needs: prepare-environment
+    runs-on:
+      - self-hosted
+      - gitlab-org-docker
+    container:
+      image: python:3.12.0-slim
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "web" || ${{ github.event_name }} == "api" || ${{ github.event_name }} == "push" && ${{ github.ref }} == $CI_DEFAULT_BRANCH
+    timeout-minutes: 60
+    env:
+      PIP_CACHE_DIR: "${{ github.workspace }}/.cache/pip"
+      POETRY_VERSION: 1.6.1
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+    - uses: actions/cache@v3.3.2
+      with:
+        path: ".cache/pip"
+        key: default
+    - uses: actions/download-artifact@v4.1.0
+    - run: pip install poetry==$POETRY_VERSION
+    - run: poetry install
+    - run: echo "Publishing application..."
+    - run: poetry publish --build --no-interaction --username __token__ --password $PYPI_TOKEN
+    - run: echo "Application successfully published."
+  create-release:
+    needs:
+    - prepare-environment
+    - publish-job
+    runs-on:
+      - self-hosted
+      - gitlab-org-docker
+    container:
+      image: registry.gitlab.com/gitlab-org/release-cli:latest
+    if: # Unable to map conditional expression to GitHub Actions equivalent
+#         ${{ github.event_name }} == "web" || ${{ github.event_name }} == "api" || ${{ github.event_name }} == "push" && ${{ github.ref }} == $CI_DEFAULT_BRANCH
+    timeout-minutes: 60
+    continue-on-error: true
+    env:
+      PIP_CACHE_DIR: "${{ github.workspace }}/.cache/pip"
+      POETRY_VERSION: 1.6.1
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+    - uses: actions/download-artifact@v4.1.0
+    - run: echo 'Creating release for version $VERSION'
+    - uses: softprops/action-gh-release@v0.1.15
+      with:
+        tag_name: "$VERSION"
+        name: Release $VERSION
+        target_commitish: "${{ github.sha }}"
+        body: "$CI_COMMIT_MESSAGE"


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/sustineo/spotify-utils) :tada:

## Manual steps

Perform the following steps to complete the migration:

### sustineo/spotify-utils
- [ ] Ensure a runner with the following labels exists: gitlab-org-docker
- [ ] Ensure secret is available: `${{ secrets.PYPI_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.SPOTIFY_UTILS_CLIENT_ID }}`
- [ ] Ensure secret is available: `${{ secrets.SPOTIFY_UTILS_CLIENT_SECRET }}`
- [ ] Ensure secret is available: `${{ secrets.SPOTIFY_UTILS_REDIRECT_URI }}`
- [ ] Ensure secret is available: `${{ secrets.DOCKERHUB_TOKEN }}`
- [ ] Ensure secret is available: `${{ secrets.CONTAINER_REGISTRY_USER }}`
- [ ] Ensure secret is available: `${{ secrets.CONTAINER_REGISTRY_PASSWORD }}`