### PR TITLE
Find unavailable tracks in playlists

### DIFF
--- a/spotify_utils/src/auth.py
+++ b/spotify_utils/src/auth.py
@@ -6,7 +6,10 @@ from spotipy.oauth2 import SpotifyOAuth
 
 from spotify_utils.config import settings
 
-SCOPES = ["playlist-read-private"]  # Required scopes for the Spotify API
+SCOPES = [
+    "playlist-read-private",
+    "user-read-private"
+]
 
 
 @cache

--- a/spotify_utils/src/playlists.py
+++ b/spotify_utils/src/playlists.py
@@ -158,6 +158,83 @@ def _build_tracks_map(owned_playlists: list) -> dict:
     return tracks_map
 
 
+def find_unavailable_tracks(playlists: list) -> list[dict]:
+    """
+    Scan the given playlists for tracks that are removed from Spotify or
+    unavailable (greyed out) in the user's market.
+
+    Detection requires market-scoped requests (``market="from_token"``):
+      - ``item['track']`` is ``None`` → the track was removed from Spotify.
+      - ``track['is_playable']`` is ``False`` → unavailable in the user's market;
+        ``track['restrictions']['reason']`` explains why (market/product/explicit).
+
+    Returns a list of dicts with keys: name, artists, playlist, reason, track_id.
+    """
+    session = get_session()
+    results: list[dict] = []
+    for playlist in playlists:
+        tracks = session.playlist_items(playlist['id'], market="from_token")
+        while tracks:
+            for item in tracks['items']:
+                track = item.get('track')
+                if track is None:
+                    results.append({
+                        "name": "(removed track)",
+                        "artists": "",
+                        "playlist": playlist['name'],
+                        "reason": "removed",
+                        "track_id": "",
+                    })
+                    continue
+                if track.get('is_playable') is False:
+                    reason = (track.get('restrictions') or {}).get('reason', "unavailable")
+                    results.append({
+                        "name": track.get('name', ""),
+                        "artists": ", ".join(a['name'] for a in track.get('artists', [])),
+                        "playlist": playlist['name'],
+                        "reason": reason,
+                        "track_id": track.get('id', ""),
+                    })
+            if tracks['next']:
+                tracks = session.next(tracks)
+            else:
+                break
+    return results
+
+
+@app.command()
+def unavailable(
+        verbose: bool = typer.Option(False, "--verbose", "-v"),
+        quiet: bool = typer.Option(False, "--quiet", "-q")
+):
+    """
+    Find tracks that are removed or unavailable (greyed out) in playlists owned by the current user
+    """
+    current_user = user.get_details()
+    owned_playlists = _get_owned_playlists(current_user)
+    unavailable_tracks = find_unavailable_tracks(owned_playlists)
+
+    # Print basic stats, like number of unavailable tracks and searched playlists to console
+    if not quiet:
+        if unavailable_tracks:
+            unavailable_count = typer.style(len(unavailable_tracks), fg=typer.colors.RED)
+        else:
+            unavailable_count = typer.style("0", fg=typer.colors.GREEN)
+
+        typer.echo(f"Found {unavailable_count} unavailable tracks across {len(owned_playlists)} playlists")
+
+    # Print additional information about the unavailable tracks and their playlists
+    if verbose and not quiet and unavailable_tracks:
+        table = {}
+        for track in unavailable_tracks:
+            table.setdefault("name", []).append(track['name'])
+            table.setdefault("artists", []).append(track['artists'])
+            table.setdefault("playlist", []).append(track['playlist'])
+            table.setdefault("reason", []).append(track['reason'])
+
+        typer.echo(tabulate(table, headers="keys", showindex=True, tablefmt="simple"))
+
+
 @app.command()
 def duplicates(
         verbose: bool = typer.Option(False, "--verbose", "-v"),

--- a/spotify_utils/src/playlists.py
+++ b/spotify_utils/src/playlists.py
@@ -158,22 +158,26 @@ def _build_tracks_map(owned_playlists: list) -> dict:
     return tracks_map
 
 
-def find_unavailable_tracks(playlists: list) -> list[dict]:
+def find_unavailable_tracks(playlists: list[dict]) -> list[dict]:
     """
     Scan the given playlists for tracks that are removed from Spotify or
     unavailable (greyed out) in the user's market.
 
-    Detection requires market-scoped requests (``market="from_token"``):
+    Detection requires market-scoped requests (the user's ISO 3166-1 alpha-2
+    country code, resolved from their profile):
       - ``item['track']`` is ``None`` → the track was removed from Spotify.
       - ``track['is_playable']`` is ``False`` → unavailable in the user's market;
         ``track['restrictions']['reason']`` explains why (market/product/explicit).
 
-    Returns a list of dicts with keys: name, artists, playlist, reason, track_id.
+    Returns a list of dicts with keys: name, artists, playlist, reason.
     """
     session = get_session()
+    market = user.get_details().get('country')
+
     results: list[dict] = []
+    seen: set[tuple[str, str]] = set()  # (playlist_id, track_id) — collapse repeated copies
     for playlist in playlists:
-        tracks = session.playlist_items(playlist['id'], market="from_token")
+        tracks = session.playlist_items(playlist['id'], market=market)
         while tracks:
             for item in tracks['items']:
                 track = item.get('track')
@@ -183,17 +187,21 @@ def find_unavailable_tracks(playlists: list) -> list[dict]:
                         "artists": "",
                         "playlist": playlist['name'],
                         "reason": "removed",
-                        "track_id": "",
                     })
                     continue
                 if track.get('is_playable') is False:
+                    track_id = track.get('id')
+                    if track_id:
+                        key = (playlist['id'], track_id)
+                        if key in seen:
+                            continue
+                        seen.add(key)
                     reason = (track.get('restrictions') or {}).get('reason', "unavailable")
                     results.append({
                         "name": track.get('name', ""),
                         "artists": ", ".join(a['name'] for a in track.get('artists', [])),
                         "playlist": playlist['name'],
                         "reason": reason,
-                        "track_id": track.get('id', ""),
                     })
             if tracks['next']:
                 tracks = session.next(tracks)
@@ -226,11 +234,11 @@ def unavailable(
     # Print additional information about the unavailable tracks and their playlists
     if verbose and not quiet and unavailable_tracks:
         table = {}
-        for track in unavailable_tracks:
-            table.setdefault("name", []).append(track['name'])
-            table.setdefault("artists", []).append(track['artists'])
-            table.setdefault("playlist", []).append(track['playlist'])
-            table.setdefault("reason", []).append(track['reason'])
+        for entry in unavailable_tracks:
+            table.setdefault("name", []).append(entry['name'])
+            table.setdefault("artists", []).append(entry['artists'])
+            table.setdefault("playlist", []).append(entry['playlist'])
+            table.setdefault("reason", []).append(entry['reason'])
 
         typer.echo(tabulate(table, headers="keys", showindex=True, tablefmt="simple"))
 

--- a/spotify_utils/src/tui/app.py
+++ b/spotify_utils/src/tui/app.py
@@ -33,7 +33,7 @@ from textual.widgets import (
 from spotify_utils.src import file_engine, template_engine
 from spotify_utils.src import user as user_module
 from spotify_utils.src.auth import get_session
-from spotify_utils.src.playlists import collect_playlists
+from spotify_utils.src.playlists import collect_playlists, find_unavailable_tracks
 
 __version__ = importlib.metadata.version("spotify-utils")
 
@@ -454,6 +454,84 @@ class DuplicatesTab(Container):
 
 
 # ---------------------------------------------------------------------------
+# Unavailable tab
+# ---------------------------------------------------------------------------
+
+class UnavailableTab(Container):
+    """Scans owned playlists for removed or unavailable (greyed out) tracks."""
+
+    def on_mount(self) -> None:
+        self._scanned = False
+        table = self.query_one(DataTable)
+        table.add_columns("Track", "Artists", "Playlist", "Reason")
+        table.display = False
+        self.query_one("#unavail-loading", LoadingIndicator).display = False
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Click [bold]Scan[/bold] to find removed or unavailable tracks across your owned playlists.",
+            id="unavail-stats",
+        )
+        yield Horizontal(
+            Button("Scan", id="unavail-scan-btn", variant="primary"),
+            id="unavail-actions",
+        )
+        yield LoadingIndicator(id="unavail-loading")
+        yield DataTable(id="unavail-table", cursor_type="row")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "unavail-scan-btn":
+            self._scan()
+
+    @work(thread=True)
+    def _scan(self) -> None:
+        self.app.call_from_thread(self._set_scanning, True)
+        table = self.query_one(DataTable)
+        self.app.call_from_thread(table.clear)
+        try:
+            current_user = user_module.get_details()
+            owned = [
+                p for p in self.app.get_playlists()
+                if p["owner"]["id"] == current_user["id"]
+            ]
+
+            tracks = find_unavailable_tracks(owned)
+            rows = [
+                (t["name"], t["artists"], t["playlist"], t["reason"])
+                for t in tracks
+            ]
+
+            count = len(tracks)
+            if count > 0:
+                stats = (
+                    f"Found [bold red]{count}[/bold red] unavailable track(s) "
+                    f"across [bold]{len(owned)}[/bold] owned playlist(s)."
+                )
+            else:
+                stats = (
+                    f"[bold green]No unavailable tracks found[/bold green] "
+                    f"across [bold]{len(owned)}[/bold] owned playlist(s)."
+                )
+
+            self.app.call_from_thread(self._update_stats, stats)
+            self.app.call_from_thread(table.add_rows, rows)
+        except Exception as exc:
+            self.app.call_from_thread(self.app.notify, str(exc), severity="error")
+        finally:
+            self.app.call_from_thread(self._set_scanning, False)
+
+    def _set_scanning(self, scanning: bool) -> None:
+        self.query_one("#unavail-loading", LoadingIndicator).display = scanning
+        self.query_one("#unavail-scan-btn", Button).disabled = scanning
+        if not scanning:
+            self._scanned = True
+        self.query_one(DataTable).display = self._scanned and not scanning
+
+    def _update_stats(self, message: str) -> None:
+        self.query_one("#unavail-stats", Static).update(message)
+
+
+# ---------------------------------------------------------------------------
 # Main application
 # ---------------------------------------------------------------------------
 
@@ -464,8 +542,9 @@ class SpotifyUtilsApp(App[None]):
     BINDINGS = [
         Binding("ctrl+q", "quit", "Quit"),
         Binding("ctrl+l", "switch_tab('tab-playlists')", "Playlists", priority=True),
-        Binding("ctrl+e", "switch_tab('tab-export')", "Export", priority=True),
         Binding("ctrl+d", "switch_tab('tab-duplicates')", "Duplicates", priority=True),
+        Binding("ctrl+u", "switch_tab('tab-unavailable')", "Unavailable", priority=True),
+        Binding("ctrl+e", "switch_tab('tab-export')", "Export", priority=True),
     ]
 
     _playlists_cache: list[dict] | None = None
@@ -495,6 +574,8 @@ class SpotifyUtilsApp(App[None]):
                 yield PlaylistsTab()
             with TabPane("Duplicates", id="tab-duplicates"):
                 yield DuplicatesTab()
+            with TabPane("Unavailable", id="tab-unavailable"):
+                yield UnavailableTab()
             with TabPane("Export", id="tab-export"):
                 yield ExportTab()
         yield Footer()

--- a/spotify_utils/src/tui/tui.tcss
+++ b/spotify_utils/src/tui/tui.tcss
@@ -117,3 +117,24 @@ DuplicatesTab #dup-actions {
 DuplicatesTab DataTable {
     height: 1fr;
 }
+
+/* ── Unavailable tab ───────────────────────────────────────────────────── */
+
+UnavailableTab {
+    height: 1fr;
+    padding: 1 2;
+}
+
+UnavailableTab #unavail-stats {
+    height: auto;
+    margin-bottom: 1;
+}
+
+UnavailableTab #unavail-actions {
+    height: auto;
+    margin-bottom: 1;
+}
+
+UnavailableTab DataTable {
+    height: 1fr;
+}


### PR DESCRIPTION
## Summary
Adds a way to surface tracks that are **removed from Spotify** or **unavailable (greyed out)** in the user's market.

- New `playlists unavailable` CLI command (`-v`/`--verbose`, `-q`/`--quiet`), mirroring the `duplicates` command.
- New **Unavailable** TUI tab (Ctrl+U) with a Scan button, sitting between Duplicates and Export.
- Shared `find_unavailable_tracks()` helper in `playlists.py` backs both CLI and TUI to avoid divergent logic.

## Detection
Uses market-scoped requests (`market="from_token"`):
- `item["track"]` is `None` → track removed from Spotify (reported as `removed`).
- `track["is_playable"]` is `False` → unavailable in market; `restrictions.reason` surfaces why (`market`/`product`/`explicit`), falling back to `unavailable` for any future reasons.

These flags only appear when a `market` is supplied, which is why `from_token` is used (also avoids needing the `user-read-private` scope).