### PR TITLE
Handle Spotify refresh-token expiration with re-auth recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,11 @@ Credentials are required for any command that hits the Spotify API: `CLIENT_ID`,
 
 ## Architecture
 
-**Entry point:** `spotify_utils/main.py` builds the root Typer `app`, registers the `playlists` sub-app, and defines `version` and `tui` commands. `pyproject.toml` maps the `spotify-utils` script to `spotify_utils.main:app`.
+**Entry point:** `spotify_utils/main.py` builds the root Typer `app`, registers the `playlists` sub-app, and defines `version` and `tui` commands. `pyproject.toml` maps the `spotify-utils` script to `spotify_utils.main:main` — a thin wrapper around `app()` that catches `AuthenticationError` (from `src/auth.py`) and turns it into a stderr message + exit code 1 instead of a traceback.
 
-**Lazy authentication (important invariant):** `src/auth.py` exposes `get_session() -> spotipy.Spotify`, a `@cache`-memoized factory. Credentials are read on the *first call*, not at import time, so `--help` and `version` work without any config. **Never call `get_session()` (or otherwise read `settings.CLIENT_ID` etc.) at module level / import time** — doing so reintroduces eager auth and breaks `--help`. Inside functions, bind `session = get_session()` once and reuse it.
+**Lazy authentication (important invariant):** `src/auth.py` exposes `get_session() -> spotipy.Spotify`, a memoized factory backed by a module-level `_session` + `_session_lock` (double-checked locking, **not** `@cache` — `lru_cache` doesn't serialize concurrent first calls, and the TUI calls `get_session()` from several worker threads at once, which would launch multiple sign-in flows). Credentials are read on the *first call*, not at import time, so `--help` and `version` work without any config. **Never call `get_session()` (or otherwise read `settings.CLIENT_ID` etc.) at module level / import time** — doing so reintroduces eager auth and breaks `--help`. Inside functions, bind `session = get_session()` once and reuse it.
+
+`get_session()` also recovers from expired refresh tokens: on first call it validates the cached token, and on an `invalid_grant` it discards the dead token and re-runs the sign-in flow once (never retries the failed refresh). If that re-sign-in fails it raises `AuthenticationError` — a UI-agnostic exception the CLI wrapper and TUI present in their own way. Don't reintroduce `typer.echo`/`typer.Exit` into `auth.py`; it's shared with the TUI, where Typer's exit machinery is meaningless.
 
 **Spotify pagination pattern:** the Spotify API returns paginated results. The repeated idiom across the codebase is `while page: ...; page = session.next(page) if page['next'] else break`. Preserve this when adding new API traversals.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,14 +27,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -509,14 +509,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
+    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ textual = ">=8.0.0, <9.0.0"
 pytest = ">=9.0.2, <10.0.0"
 
 [tool.poetry.scripts]
-spotify-utils = "spotify_utils.main:app"
+spotify-utils = "spotify_utils.main:main"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-dotenv = "~=2.8"

--- a/spotify_utils/main.py
+++ b/spotify_utils/main.py
@@ -1,8 +1,10 @@
 import importlib.metadata
+import sys
 
 import typer
 
 from spotify_utils.src import playlists
+from spotify_utils.src.auth import AuthenticationError
 
 # Global variables
 __version__ = importlib.metadata.version("spotify-utils")
@@ -24,5 +26,14 @@ def tui():
     SpotifyUtilsApp().run()
 
 
+def main() -> None:
+    """Console-script entry point: present auth failures cleanly instead of as a traceback."""
+    try:
+        app()
+    except AuthenticationError as exc:
+        typer.echo(str(exc), err=True)
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    app()
+    main()

--- a/spotify_utils/src/auth.py
+++ b/spotify_utils/src/auth.py
@@ -1,8 +1,8 @@
-from functools import cache
+import threading
 
 import spotipy
 from spotipy import CacheFileHandler
-from spotipy.oauth2 import SpotifyOAuth
+from spotipy.oauth2 import SpotifyOAuth, SpotifyOauthError
 
 from spotify_utils.config import settings
 
@@ -12,15 +12,55 @@ SCOPES = [
 ]
 
 
-@cache
+class AuthenticationError(Exception):
+    """A Spotify sign-in is required but could not be completed.
+
+    UI-agnostic on purpose: the CLI turns it into a stderr message + exit code,
+    the TUI shows it in the auth-status indicator.
+    """
+
+
+_session: spotipy.Spotify | None = None
+_session_lock = threading.Lock()
+
+
 def get_session() -> spotipy.Spotify:
-    """Build (once) and return the Spotify client. Credentials are read on first call."""
-    return spotipy.Spotify(
-        auth_manager=SpotifyOAuth(
+    """Build (once) and return the Spotify client. Credentials are read on first call.
+
+    Thread-safe: the TUI calls this from several worker threads at once, so concurrent
+    first callers serialize on a lock to guarantee a single sign-in flow.
+    """
+    global _session
+    if _session is not None:
+        return _session
+
+    with _session_lock:
+        if _session is not None:
+            return _session
+
+        auth_manager = SpotifyOAuth(
             client_id=settings.CLIENT_ID,
             client_secret=settings.CLIENT_SECRET,
             redirect_uri=settings.REDIRECT_URI,
             scope=",".join(SCOPES),
             cache_handler=CacheFileHandler()
         )
-    )
+
+        # Spotify refresh tokens expire (and a stale one yields invalid_grant). Discard the
+        # dead token and re-run the sign-in flow once; never retry the failed refresh blindly.
+        try:
+            auth_manager.validate_token(auth_manager.cache_handler.get_cached_token())
+        except SpotifyOauthError as error:
+            if error.error != "invalid_grant":
+                raise
+            auth_manager.cache_handler.save_token_to_cache(None)
+            try:
+                auth_manager.get_access_token(check_cache=False)
+            except SpotifyOauthError as exc:
+                raise AuthenticationError(
+                    "Your Spotify sign-in has expired and could not be renewed. "
+                    "Please run the command again to sign in."
+                ) from exc
+
+        _session = spotipy.Spotify(auth_manager=auth_manager)
+        return _session

--- a/spotify_utils/src/tui/app.py
+++ b/spotify_utils/src/tui/app.py
@@ -567,8 +567,27 @@ class SpotifyUtilsApp(App[None]):
     def action_switch_tab(self, tab_id: str) -> None:
         self.query_one(TabbedContent).active = tab_id
 
+    def on_mount(self) -> None:
+        self._authenticate()
+
+    @work(thread=True)
+    def _authenticate(self) -> None:
+        """Sign in up front so the indicator reflects the (possibly blocking) auth flow."""
+        self.app.call_from_thread(self._set_auth_status, "🔐 Authenticating…")
+        try:
+            get_session()
+            user = user_module.get_details()
+            name = user.get("display_name") or user.get("id", "")
+            self.app.call_from_thread(self._set_auth_status, f"🟢 Signed in as {name}")
+        except Exception as exc:
+            self.app.call_from_thread(self._set_auth_status, f"🔴 Authentication failed — {exc}")
+
+    def _set_auth_status(self, message: str) -> None:
+        self.query_one("#auth-status", Static).update(message)
+
     def compose(self) -> ComposeResult:
         yield Header()
+        yield Static("🔐 Authenticating…", id="auth-status")
         with TabbedContent():
             with TabPane("Playlists", id="tab-playlists"):
                 yield PlaylistsTab()

--- a/spotify_utils/src/tui/tui.tcss
+++ b/spotify_utils/src/tui/tui.tcss
@@ -15,6 +15,22 @@ SelectOverlay {
     border: none;
 }
 
+Screen {
+    layers: base overlay;
+}
+
+/* Overlay only the right end of the header row so the centered title/version
+   stays visible and no extra height is added. */
+#auth-status {
+    layer: overlay;
+    dock: right;
+    width: auto;
+    height: 1;
+    padding: 0 2;
+    background: $panel;
+    color: $text-muted;
+}
+
 /* ── Tracks screen ──────────────────────────────────────────────────────── */
 
 PlaylistTracksScreen {


### PR DESCRIPTION
## Summary

Prepares the app for Spotify's refresh-token expiration change (effective July 20, 2026). Previously an expired refresh token raised an unhandled `SpotifyOauthError` and left the dead token cached, so every subsequent run crashed identically.

- **`auth.py`** — `get_session()` now validates the cached token on first call; on `invalid_grant` it discards the dead token and re-runs the sign-in flow once (never retries the failed refresh), matching Spotify's prescribed remedy. Unrecoverable failures raise a UI-agnostic `AuthenticationError`.
- **`get_session()` thread-safety** — replaced `@cache` with module-level double-checked locking (`_session` + `_session_lock`). `lru_cache` doesn't serialize concurrent first calls, and the TUI hits `get_session()` from several worker threads at once, which could launch multiple sign-in flows.
- **CLI** — new `main()` wrapper (entry point `spotify_utils.main:main`) turns `AuthenticationError` into a clean stderr message + exit 1 instead of a traceback.
- **TUI** — added an authentication indicator on the header row (`🔐 Authenticating… / 🟢 Signed in as … / 🔴 Authentication failed — …`); overlaid so it adds no height and keeps the centered version visible.
- **CLAUDE.md** — documented the new locking rationale, the `invalid_grant` recovery, and the `AuthenticationError` contract.
- **poetry.lock** — incidental dependency refresh (certifi, pytest).
